### PR TITLE
Fix CI and prototype CD

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,0 +1,56 @@
+name: cd
+on:
+  push:
+    tags:
+    - 'v[0-9]+.[0-9]+.[0-9]+.*'
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - name: setup python
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
+        with:
+          python-version: "3.8"
+      - name: install
+        run: pip install .[dev]
+      - name: build package
+        run: python setup.py bdist_wheel
+      - name: build docker image
+        run: docker build . --tag gravitational/aws-quota-checker:test
+
+  build_and_push_docker_image:
+    runs-on: ubuntu-latest
+    needs: [test]
+    name: Build and push Docker image
+    env:
+      AWS_REGION: us-west-2
+      AWS_ROLE: TBD
+    steps:
+      - name: checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
+        with:
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.CR_PAT }}
+      - name: setup docker buildx
+        uses: docker/setup-buildx-action@v2
+      - name: build docker image
+        run: docker build . --tag gravitational/aws-quota-checker:staged
+      - name: configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE }}
+      - name: login to ECR
+        uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
+      - name: push docker image
+        run: |
+          docker tag gravitational/aws-quota-checker:staged gravitational/aws-quota-checker:${GITHUB_REF##*/}
+          docker push gravitational/aws-quota-checker:${GITHUB_REF##*/}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,11 @@
 on:
   pull_request:
     branches:
+      - teleport
       - master
   push:
     branches:
+      - teleport
       - master
     tags:
       - "*"
@@ -12,14 +14,15 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
       - name: setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
         with:
           python-version: "3.8"
       - name: install
         run: pip install .
       - name: run all checks
+        if: ${{ false }}
         run: aws-quota-checker check all
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
@@ -31,9 +34,9 @@ jobs:
     needs: test
     if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
       - name: setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
         with:
           python-version: "3.8"
       - name: install
@@ -44,12 +47,12 @@ jobs:
       - name: build package
         run: python setup.py bdist_wheel
       - name: publish package
-        uses: pypa/gh-action-pypi-publish@v1.4.2
+        uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e # v1.8.10
         with:
           user: __token__
           password: ${{ secrets.PYPI_API_TOKEN }}
       - name: create Release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -62,23 +65,27 @@ jobs:
     needs: test
     name: Build and push Docker image
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
       - name: Login to GitHub Container Registry
-        uses: docker/login-action@v1
+        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
         with:
-          registry: ghcr.io
           username: ${{ github.repository_owner }}
           password: ${{ secrets.CR_PAT }}
       - name: Build Docker image
-        run: docker build . --tag ghcr.io/brennerm/aws-quota-checker:latest
+        run: docker build . --tag gravitational/aws-quota-checker:latest
       - name: Push Docker image for branch
-        if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
+        if: ${{ github.ref == 'refs/heads/teleport' && github.event_name == 'push' }}
         run: |
-          docker tag ghcr.io/brennerm/aws-quota-checker:latest ghcr.io/brennerm/aws-quota-checker:master
-          docker push ghcr.io/brennerm/aws-quota-checker:master
+          docker tag gravitational/aws-quota-checker:latest gravitational/aws-quota-checker:teleport
+          docker push gravitational/aws-quota-checker:teleport
+      - name: Push Docker image for branch
+        if: ${{ github.ref == 'refs/heads/teleport' && github.event_name == 'push' }}
+        run: |
+          docker tag gravitational/aws-quota-checker:latest gravitational/aws-quota-checker:teleport
+          docker push gravitational/aws-quota-checker:teleport
       - name: Push Docker image for tag
         if: ${{ startsWith(github.ref, 'refs/tags') && github.event_name == 'push' }}
         run: |
-          docker tag ghcr.io/brennerm/aws-quota-checker:latest ghcr.io/brennerm/aws-quota-checker:${GITHUB_REF##*/}
-          docker push ghcr.io/brennerm/aws-quota-checker:latest
-          docker push ghcr.io/brennerm/aws-quota-checker:${GITHUB_REF##*/}
+          docker tag gravitational/aws-quota-checker:latest gravitational/aws-quota-checker:${GITHUB_REF##*/}
+          docker push gravitational/aws-quota-checker:latest
+          docker push gravitational/aws-quota-checker:${GITHUB_REF##*/}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,78 +2,19 @@ on:
   pull_request:
     branches:
       - teleport
-  push:
-    branches:
-      - teleport
-    tags:
-      - "*"
-
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - name: setup Python
-        uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
-        with:
-          python-version: "3.8"
-      - name: install
-        run: pip install .
-      - name: build package
-        run: python setup.py bdist_wheel
-
-  release:
-    runs-on: ubuntu-latest
-    needs: test
-    if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - name: setup Python
+      - name: checkout
+        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+      - name: setup python
         uses: actions/setup-python@61a6322f88396a6271a6ee3565807d608ecaddd1 # v4
         with:
           python-version: "3.8"
       - name: install
         run: pip install .[dev]
-      - name: get changelog entry
-        id: changelog
-        run: python tools/extract-changelog-entry.py ${GITHUB_REF#refs/tags/} > changelog_entry
       - name: build package
         run: python setup.py bdist_wheel
-      - name: create Release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          tag_name: ${{ github.ref }}
-          release_name: Release ${{ github.ref }}
-          body_path: changelog_entry
-
-  build_and_push_docker_image:
-    runs-on: ubuntu-latest
-    needs: test
-    name: Build and push Docker image
-    steps:
-      - uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-        with:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
-      - name: Build Docker image
-        run: docker build . --tag gravitational/aws-quota-checker:latest
-      - name: Push Docker image for branch
-        if: ${{ github.ref == 'refs/heads/teleport' && github.event_name == 'push' }}
-        run: |
-          docker tag gravitational/aws-quota-checker:latest gravitational/aws-quota-checker:teleport
-          docker push gravitational/aws-quota-checker:teleport
-      - name: Push Docker image for branch
-        if: ${{ github.ref == 'refs/heads/teleport' && github.event_name == 'push' }}
-        run: |
-          docker tag gravitational/aws-quota-checker:latest gravitational/aws-quota-checker:teleport
-          docker push gravitational/aws-quota-checker:teleport
-      - name: Push Docker image for tag
-        if: ${{ startsWith(github.ref, 'refs/tags') && github.event_name == 'push' }}
-        run: |
-          docker tag gravitational/aws-quota-checker:latest gravitational/aws-quota-checker:${GITHUB_REF##*/}
-          docker push gravitational/aws-quota-checker:latest
-          docker push gravitational/aws-quota-checker:${GITHUB_REF##*/}
+      - name: build docker image
+        run: docker build . --tag gravitational/aws-quota-checker:test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,9 @@ on:
   pull_request:
     branches:
       - teleport
-      - master
   push:
     branches:
       - teleport
-      - master
     tags:
       - "*"
 
@@ -21,15 +19,10 @@ jobs:
           python-version: "3.8"
       - name: install
         run: pip install .
-      - name: run all checks
-        if: ${{ false }}
-        run: aws-quota-checker check all
-        env:
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          AWS_DEFAULT_REGION: eu-central-1
+      - name: build package
+        run: python setup.py bdist_wheel
 
-  publish:
+  release:
     runs-on: ubuntu-latest
     needs: test
     if: success() && github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
@@ -46,11 +39,6 @@ jobs:
         run: python tools/extract-changelog-entry.py ${GITHUB_REF#refs/tags/} > changelog_entry
       - name: build package
         run: python setup.py bdist_wheel
-      - name: publish package
-        uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e # v1.8.10
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
       - name: create Release
         uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:

--- a/.github/workflows/test-and-publish.yml
+++ b/.github/workflows/test-and-publish.yml
@@ -1,12 +1,4 @@
-on:
-  pull_request:
-    branches:
-      - master
-  push:
-    branches:
-      - master
-    tags:
-      - "*"
+on: workflow_dispatch
 
 jobs:
   test:

--- a/renovate.json
+++ b/renovate.json
@@ -2,9 +2,12 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "forkProcessing": "enabled",
   "baseBranches": [
-    "master"
+    "teleport"
   ],
   "extends": [
     "config:best-practices"
   ]
+  "ignorePaths": {
+    ".github/workflows/test-and-publish.yml"
+  }
 }


### PR DESCRIPTION
In this PR I:

1. Restore `.github/workflows/test-and-publish.yml` to its upstream state
2. Exclude `.github/workflows/test-and-publish.yml` it from renovate
3. disable `.github/workflows/test-and-publish.yml` triggers
4. create `.github/workflows/ci.yml` and `.github/workflows/cd.yml` 
5. Remove the broken CI check against a live AWS account (I may restore this later)
6. Remove publishing to PyPi
7. Swap docker uploads to target ECR

The net of this is: we should expect CI to be green again, and CD to get closer to functional.

Furthermore, we'll avoid GHA merge conflicts, as we don't really expect our actions to look much like upstream's actions.