### PR TITLE
Remove extraneous period

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,7 @@ name: cd
 on:
   push:
     tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+.*'
+    - 'v[0-9]+.[0-9]+.[0-9]+*'
 
 permissions:
   contents: read


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#filter-pattern-cheat-sheet

Per the pattern cheat sheet. Regex is not completely supported and the period is a literal character. 