### PR TITLE
Build and Push Image on push to teleport branch.

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,7 +30,7 @@ jobs:
     needs: [test]
     name: Build and push Docker image
     env:
-      AWS_REGION: us-west-2
+      AWS_REGION: us-east-1
       AWS_ROLE: arn:aws:iam::146628656107:role/aws-quota-checker-github-action-ecr-role
     steps:
       - name: checkout

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -31,7 +31,7 @@ jobs:
     name: Build and push Docker image
     env:
       AWS_REGION: us-west-2
-      AWS_ROLE: arn:aws:iam::146628656107:role/cloud-github-action-ecr-role
+      AWS_ROLE: arn:aws:iam::146628656107:role/aws-quota-checker-github-action-ecr-role
     steps:
       - name: checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -47,6 +47,8 @@ jobs:
       - name: login to ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
+        with:
+          registry-type: public
       - name: export ECR Repository
         run: |
           echo "ECR_REPOSITORY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,6 +30,7 @@ jobs:
     needs: [test]
     name: Build and push Docker image
     env:
+      AWS_REGION: us-west-2
       AWS_ROLE: arn:aws:iam::146628656107:role/aws-quota-checker-github-action-ecr-role
     steps:
       - name: checkout

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,8 +1,8 @@
 name: cd
 on:
   push:
-    tags:
-    - 'v[0-9]+.[0-9]+.[0-9]+*'
+    branches:
+    - teleport
 
 permissions:
   contents: read
@@ -49,10 +49,19 @@ jobs:
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v1
         with:
           registry-type: public
+      - name: Get Time
+        id: time
+        uses: nanzm/get-time-action@887e4db9af58ebae64998b7105921b816af77977 # v2.0
+        with:
+          format: "%Y%m%dT%H%M%S"
+      - name: Inject slug/short variables
+        uses: rlespinasse/github-slug-action@102b1a064a9b145e56556e22b18b19c624538d94 # v4.4.1
+      - name: export ECR Tag
+        run: echo "ECR_TAG=${{ env.GITHUB_REF_SLUG }}-${{ env.GITHUB_SHA_SHORT }}-${{ steps.time.outputs.time }}" >> $GITHUB_ENV
       - name: export ECR Repository
         run: |
           echo "ECR_REPOSITORY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
       - name: push docker image
         run: |
-          docker tag gravitational/aws-quota-checker:staged ${ECR_REPOSITORY}/gravitational/aws-quota-checker:${GITHUB_REF##*/}
-          docker push ${ECR_REPOSITORY}/gravitational/aws-quota-checker:${GITHUB_REF##*/}
+          docker tag gravitational/aws-quota-checker:staged ${ECR_REPOSITORY}/gravitational/aws-quota-checker:${ECR_TAG}
+          docker push ${ECR_REPOSITORY}/gravitational/aws-quota-checker:${ECR_TAG}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,7 +30,6 @@ jobs:
     needs: [test]
     name: Build and push Docker image
     env:
-      AWS_REGION: us-west-2
       AWS_ROLE: arn:aws:iam::146628656107:role/aws-quota-checker-github-action-ecr-role
     steps:
       - name: checkout
@@ -40,13 +39,13 @@ jobs:
       - name: build docker image
         run: docker build . --tag gravitational/aws-quota-checker:staged
       - name: configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@8c3f20df09ac63af7b3ae3d7c91f105f857d8497 # v4
+        uses: aws-actions/configure-aws-credentials@010d0da01d0b5a38af31e9c3470dbfdabdecca3a # v4
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE }}
       - name: login to ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v1
         with:
           registry-type: public
       - name: export ECR Repository

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   test:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -30,15 +30,10 @@ jobs:
     name: Build and push Docker image
     env:
       AWS_REGION: us-west-2
-      AWS_ROLE: TBD
+      AWS_ROLE: arn:aws:iam::146628656107:role/cloud-github-action-ecr-role
     steps:
       - name: checkout
         uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
-      - name: Login to GitHub Container Registry
-        uses: docker/login-action@465a07811f14bebb1938fbed4728c6a1ff8901fc # v2
-        with:
-          username: ${{ github.repository_owner }}
-          password: ${{ secrets.CR_PAT }}
       - name: setup docker buildx
         uses: docker/setup-buildx-action@v2
       - name: build docker image
@@ -49,8 +44,12 @@ jobs:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE }}
       - name: login to ECR
+        id: login-ecr
         uses: aws-actions/amazon-ecr-login@2fc7aceee09e9e4a7105c0d060c656fad0b4f63d # v1
+      - name: export ECR Repository
+        run: |
+          echo "ECR_REPOSITORY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
       - name: push docker image
         run: |
-          docker tag gravitational/aws-quota-checker:staged gravitational/aws-quota-checker:${GITHUB_REF##*/}
-          docker push gravitational/aws-quota-checker:${GITHUB_REF##*/}
+          docker tag gravitational/aws-quota-checker:staged ${ECR_REPOSITORY}/gravitational/aws-quota-checker:${GITHUB_REF##*/}
+          docker push ${ECR_REPOSITORY}/gravitational/aws-quota-checker:${GITHUB_REF##*/}


### PR DESCRIPTION
Updates image publishing to be on merges to the teleport branch instead of on tag. This is pretty much a copy and paste of the actions used by the cloud repository. 