### PR TITLE
Add quota scope

### DIFF
--- a/aws_quota/check/quota_check.py
+++ b/aws_quota/check/quota_check.py
@@ -45,7 +45,10 @@ class QuotaCheck:
     def label_values(self):
         label_values = {
             'quota': self.key,
-            'account': get_account_id(self.boto_session)
+            'account': get_account_id(self.boto_session),
+            'scope': self.scope,
+            'service_code': self.service_code,
+            'quota_code': self.quota_code,
         }
 
         if self.scope in (QuotaScope.REGION, QuotaScope.INSTANCE):

--- a/aws_quota/check/quota_check.py
+++ b/aws_quota/check/quota_check.py
@@ -11,7 +11,6 @@ class QuotaScope(enum.Enum):
     REGION = 1
     INSTANCE = 2
 
-
 class QuotaCheck:
     key: str = None
     description: str = None
@@ -46,7 +45,7 @@ class QuotaCheck:
         label_values = {
             'quota': self.key,
             'account': get_account_id(self.boto_session),
-            'scope': self.scope,
+            'scope': self.scope.name,
             'service_code': self.service_code,
             'quota_code': self.quota_code,
         }

--- a/aws_quota/check/s3.py
+++ b/aws_quota/check/s3.py
@@ -4,11 +4,10 @@ from .quota_check import QuotaCheck, QuotaScope
 class BucketCountCheck(QuotaCheck):
     key = "s3_bucket_count"
     description = "The number of Amazon S3 general purpose buckets that you can create in an account"
-    scope = QuotaScope.REGION
+    scope = QuotaScope.ACCOUNT
     service_code = 's3'
     quota_code = 'L-DC2B2D3D'
 
     @property
     def current(self):
-        # TODO figure out if this is regional or account level
         return len(self.boto_session.client('s3').list_buckets()['Buckets'])


### PR DESCRIPTION
### Summary

- Add additional labels to metrics that will be helpful building dynamic dashboard (currently limits with "account" scope are duplicated for every region)
- Confirmed with AWS Support that S3 buckets limits is for the whole account