### PR TITLE
Update descriptions for all the checks

### DIFF
--- a/aws_quota/check/__init__.py
+++ b/aws_quota/check/__init__.py
@@ -29,7 +29,7 @@ def __all_subclasses(cls):
     )
 
 
-ALL_CHECKS = sorted(
+ALL_CHECKS: list[QuotaCheck] = sorted(
     [clazz for clazz in __all_subclasses(QuotaCheck) if clazz != InstanceQuotaCheck],
     key=lambda clz: clz.key,
 )

--- a/aws_quota/check/appmesh.py
+++ b/aws_quota/check/appmesh.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class MeshCountCheck(QuotaCheck):
     key = "am_mesh_count"
-    description = "App Meshes per Account"
     scope = QuotaScope.ACCOUNT
     service_code = 'appmesh'
     quota_code = 'L-AC861A39'
+    description = "Number of meshes per account"
 
     @property
     def current(self):

--- a/aws_quota/check/athena.py
+++ b/aws_quota/check/athena.py
@@ -4,10 +4,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class AthenaActiveDDLQueries(QuotaCheck):
     key = "athena_actvice_ddl_queries_count"
-    description = "The number of active DDL queries. DDL queries include CREATE TABLE and ALTER TABLE ADD PARTITION queries."
     scope = QuotaScope.REGION
     service_code = 'athena'
     quota_code = 'L-3CE0BBA0'
+    description = "The number of active DDL queries. DDL queries include CREATE TABLE and ALTER TABLE ADD PARTITION queries."
 
     @property
     def current(self):
@@ -17,10 +17,10 @@ class AthenaActiveDDLQueries(QuotaCheck):
 
 class AthenaActiveDMLQueries(QuotaCheck):
     key = "athena_actvice_dml_queries_count"
-    description = "The number of active DML queries. DML queries include SELECT, CREATE TABLE AS (CTAS), and INSERT INTO queries. The specific quotas vary by AWS Region."
     scope = QuotaScope.REGION
     service_code = 'athena'
     quota_code = 'L-FC5F6546'
+    description = "The number of active DML queries. DML queries include SELECT, CREATE TABLE AS (CTAS), and INSERT INTO queries. The specific quotas vary by AWS Region."
 
 
     @property

--- a/aws_quota/check/autoscaling.py
+++ b/aws_quota/check/autoscaling.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class AutoScalingGroupCountCheck(QuotaCheck):
     key = "asg_count"
-    description = "Auto Scaling groups per Region"
     scope = QuotaScope.REGION
     service_code = 'autoscaling'
     quota_code = 'L-CDE20ADC'
+    description = "The maximum number of Auto Scaling groups allowed for your AWS account"
 
     @property
     def current(self):
@@ -15,10 +15,10 @@ class AutoScalingGroupCountCheck(QuotaCheck):
 
 class LaunchConfigurationCountCheck(QuotaCheck):
     key = "lc_count"
-    description = "Launch configurations per Region"
     scope = QuotaScope.REGION
     service_code = 'autoscaling'
     quota_code = 'L-6B80B8FA'
+    description = "The maximum number of launch configurations allowed for your AWS account"
 
     @property
     def current(self):

--- a/aws_quota/check/cloudformation.py
+++ b/aws_quota/check/cloudformation.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class StackCountCheck(QuotaCheck):
     key = "cf_stack_count"
-    description = "Cloud Formation Stack count"
     scope = QuotaScope.ACCOUNT
     service_code = 'cloudformation'
     quota_code = 'L-0485CB21'
+    description = "Maximum number of AWS CloudFormation stacks that you can create."
 
     @property
     def current(self):

--- a/aws_quota/check/dynamodb.py
+++ b/aws_quota/check/dynamodb.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class TableCountCheck(QuotaCheck):
     key = "dyndb_table_count"
-    description = "DynamoDB Tables per Region"
     scope = QuotaScope.REGION
     service_code = 'dynamodb'
     quota_code = 'L-F98FE922'
+    description = "The maximum number of tables that can be created per region. For more information, see https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/ServiceQuotas.html#limits-tables"
 
     @property
     def current(self):

--- a/aws_quota/check/ebs.py
+++ b/aws_quota/check/ebs.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class SnapshotCountCheck(QuotaCheck):
     key = "ebs_snapshot_count"
-    description = "EBS Snapshots per Region"
     scope = QuotaScope.REGION
     service_code = 'ebs'
     quota_code = 'L-309BACF6'
+    description = "The maximum number of snapshots per Region."
 
     @property
     def current(self):

--- a/aws_quota/check/ec2.py
+++ b/aws_quota/check/ec2.py
@@ -40,10 +40,10 @@ def get_all_spot_requests(session: boto3.Session):
 
 class OnDemandStandardInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_standard_count"
-    description = "Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) EC2 instances"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-1216C47A"
+    description = "Maximum number of vCPUs assigned to the Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances."
 
     @property
     def current(self):
@@ -53,10 +53,10 @@ class OnDemandStandardInstanceCountCheck(QuotaCheck):
 
 class OnDemandFInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_f_count"
-    description = "Running On-Demand F EC2 instances"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-74FC7D96"
+    description = "Maximum number of vCPUs assigned to the Running On-Demand F instances."
 
     @property
     def current(self):
@@ -66,10 +66,10 @@ class OnDemandFInstanceCountCheck(QuotaCheck):
 
 class OnDemandGInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_g_count"
-    description = "Running On-Demand G EC2 instances"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-DB2E81BA"
+    description = "Maximum number of vCPUs assigned to the Running On-Demand G and VT instances."
 
     @property
     def current(self):
@@ -79,10 +79,10 @@ class OnDemandGInstanceCountCheck(QuotaCheck):
 
 class OnDemandInfInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_inf_count"
-    description = "Running On-Demand Inf EC2 instances"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-1945791B"
+    description = "Maximum number of vCPUs assigned to the Running On-Demand Inf instances."
 
     @property
     def current(self):
@@ -92,10 +92,10 @@ class OnDemandInfInstanceCountCheck(QuotaCheck):
 
 class OnDemandPInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_p_count"
-    description = "Running On-Demand P EC2 instances"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-417A185B"
+    description = "Maximum number of vCPUs assigned to the Running On-Demand P instances."
 
     @property
     def current(self):
@@ -105,10 +105,10 @@ class OnDemandPInstanceCountCheck(QuotaCheck):
 
 class OnDemandXInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_x_count"
-    description = "Running On-Demand X EC2 instances"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-7295265B"
+    description = "Maximum number of vCPUs assigned to the Running On-Demand X instances."
 
     @property
     def current(self):
@@ -118,10 +118,10 @@ class OnDemandXInstanceCountCheck(QuotaCheck):
 
 class SpotStandardRequestCountCheck(QuotaCheck):
     key = "ec2_spot_standard_count"
-    description = "All Standard (A, C, D, H, I, M, R, T, Z) EC2 Spot Instance Requests"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-34B43A08"
+    description = "The maximum number of vCPUs for all running or requested Standard (A, C, D, H, I, M, R, T, Z) Spot Instances per Region"
 
     @property
     def current(self):
@@ -131,10 +131,10 @@ class SpotStandardRequestCountCheck(QuotaCheck):
 
 class SpotFRequestCountCheck(QuotaCheck):
     key = "ec2_spot_f_count"
-    description = "All F EC2 Spot Instance Requests"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-88CF9481"
+    description = "The maximum number of vCPUs for all running or requested F Spot Instances per Region"
 
     @property
     def current(self):
@@ -144,10 +144,10 @@ class SpotFRequestCountCheck(QuotaCheck):
 
 class SpotGRequestCountCheck(QuotaCheck):
     key = "ec2_spot_g_count"
-    description = "All G EC2 Spot Instance Requests"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-3819A6DF"
+    description = "The maximum number of vCPUs for all running or requested G and VT Spot Instances per Region"
 
     @property
     def current(self):
@@ -157,10 +157,10 @@ class SpotGRequestCountCheck(QuotaCheck):
 
 class SpotInfRequestCountCheck(QuotaCheck):
     key = "ec2_spot_inf_count"
-    description = "All Inf EC2 Spot Instance Requests"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-B5D1601B"
+    description = "The maximum number of vCPUs for all running or requested Inf Spot Instances per Region"
 
     @property
     def current(self):
@@ -170,10 +170,10 @@ class SpotInfRequestCountCheck(QuotaCheck):
 
 class SpotPRequestCountCheck(QuotaCheck):
     key = "ec2_spot_p_count"
-    description = "All P EC2 Spot Instance Requests"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-7212CCBC"
+    description = "The maximum number of vCPUs for all running or requested P4, P3 or P2 Spot Instances per Region"
 
     @property
     def current(self):
@@ -183,10 +183,10 @@ class SpotPRequestCountCheck(QuotaCheck):
 
 class SpotXRequestCountCheck(QuotaCheck):
     key = "ec2_spot_x_count"
-    description = "All X EC2 Spot Instance Requests"
     scope = QuotaScope.ACCOUNT
     service_code = "ec2"
     quota_code = "L-E3A00192"
+    description = "The maximum number of vCPUs for all running or requested X Spot Instances per Region"
 
     @property
     def current(self):
@@ -196,10 +196,10 @@ class SpotXRequestCountCheck(QuotaCheck):
 
 class ElasticIpCountCheck(QuotaCheck):
     key = "ec2_eip_count"
-    description = "EC2 VPC Elastic IPs"
     scope = QuotaScope.ACCOUNT
     service_code = 'ec2'
     quota_code = 'L-0263D0A3'
+    description = "The maximum number of Elastic IP addresses that you can allocate for EC2-VPC in this Region."
 
     @property
     def current(self):
@@ -208,10 +208,10 @@ class ElasticIpCountCheck(QuotaCheck):
 
 class TransitGatewayCountCheck(QuotaCheck):
     key = "ec2_tgw_count"
-    description = "Transit Gateways per Account"
     scope = QuotaScope.ACCOUNT
     service_code = 'ec2'
     quota_code = 'L-A2478D36'
+    description = "Number of transit gateways per Region per account."
 
     @property
     def current(self):
@@ -220,10 +220,10 @@ class TransitGatewayCountCheck(QuotaCheck):
 
 class VpnConnectionCountCheck(QuotaCheck):
     key = "ec2_vpn_connection_count"
-    description = "VPN connections per Region"
     scope = QuotaScope.REGION
     service_code = 'ec2'
     quota_code = 'L-3E6EC3A3'
+    description = "The maximum number of Site-to-Site VPN connections that you can create per region."
 
     @property
     def current(self):
@@ -231,10 +231,10 @@ class VpnConnectionCountCheck(QuotaCheck):
 
 class LaunchTemplatesCount(QuotaCheck):
     key = "launch_templates_count"
-    description = "Maximum number of launch templates per Region per account."
     scope = QuotaScope.REGION
     service_code = 'ec2'
     quota_code = 'L-FB451C26'
+    description = "Maximum number of launch templates per Region per account."
 
     @property
     def current(self):

--- a/aws_quota/check/ecs.py
+++ b/aws_quota/check/ecs.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class ClusterCountCheck(QuotaCheck):
     key = "ecs_count"
-    description = "ECS Clusters per Region"
     scope = QuotaScope.REGION
     service_code = 'ecs'
     quota_code = 'L-21C621EB'
+    description = "Number of clusters per account"
 
     @property
     def current(self):

--- a/aws_quota/check/eks.py
+++ b/aws_quota/check/eks.py
@@ -17,10 +17,10 @@ def get_node_groups(session: boto3.Session, cluster_name) -> typing.List[str]:
 
 class ClusterCountCheck(QuotaCheck):
     key = "eks_count"
-    description = "EKS Clusters per Region"
     scope = QuotaScope.REGION
     service_code = 'eks'
     quota_code = 'L-1194D53C'
+    description = "The maximum number of EKS clusters in this account in the current Region."
 
     @property
     def current(self):
@@ -29,9 +29,9 @@ class ClusterCountCheck(QuotaCheck):
 
 class NodeGroupsPerCluster(InstanceQuotaCheck):
     key = "eks_node_groups_per_cluster_count"
-    description = "The maximum number of managed node groups per cluster."
     service_code = 'eks'
     quota_code = 'L-6D54EA21'
+    description = "The maximum number of managed node groups per cluster."
     instance_id = 'Cluster ID'
 
     @staticmethod
@@ -45,9 +45,9 @@ class NodeGroupsPerCluster(InstanceQuotaCheck):
 
 class NodesPerNodeGroup(InstanceQuotaCheck):
     key = "eks_nodes_per_node_group_count"
-    description = "The maximum number of nodes per managed node group"
     service_code = 'eks'
     quota_code = 'L-BD136A63'
+    description = "The maximum number of nodes per managed node group."
     instance_id = {'eks_cluster': None, 'eks_nodegroup': None }
 
     @staticmethod

--- a/aws_quota/check/elasticbeanstalk.py
+++ b/aws_quota/check/elasticbeanstalk.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class ApplicationCountCheck(QuotaCheck):
     key = "elasticbeanstalk_application_count"
-    description = "Elastic Beanstalk Applications per Account"
     scope = QuotaScope.ACCOUNT
     service_code = 'elasticbeanstalk'
     quota_code = 'L-1CEABD17'
+    description = "The maximum number of applications that you can create in this account in the current Region."
 
     @property
     def current(self):
@@ -15,10 +15,10 @@ class ApplicationCountCheck(QuotaCheck):
 
 class EnvironmentCountCheck(QuotaCheck):
     key = "elasticbeanstalk_environment_count"
-    description = "Elastic Beanstalk Environments per Account"
     scope = QuotaScope.ACCOUNT
     service_code = 'elasticbeanstalk'
     quota_code = 'L-8EFC1C51'
+    description = "The maximum number of environments that you can create in this account in the current Region. The limit applies across applications, not per application."
 
     @property
     def current(self):

--- a/aws_quota/check/elb.py
+++ b/aws_quota/check/elb.py
@@ -23,10 +23,10 @@ def get_classic_elbs(session: boto3.Session):
 
 class ClassicLoadBalancerCountCheck(QuotaCheck):
     key = "elb_clb_count"
-    description = "Classic Load Balancers per Region"
     scope = QuotaScope.REGION
     service_code = 'elasticloadbalancing'
     quota_code = 'L-E9E9831D'
+    description = "The maximum number of Classic Load Balancers per Region"
 
     @property
     def current(self):
@@ -35,9 +35,9 @@ class ClassicLoadBalancerCountCheck(QuotaCheck):
 
 class ListenerPerClassicLoadBalancerCountCheck(InstanceQuotaCheck):
     key = "elb_listeners_per_clb"
-    description = "Listeners per Classic Load Balancer"
     service_code = 'elasticloadbalancing'
     quota_code = 'L-1A491844'
+    description = "The maximum number of listeners per Classic Load Balancer"
     instance_id = 'Load Balancer Name'
 
     @staticmethod
@@ -58,10 +58,10 @@ class ListenerPerClassicLoadBalancerCountCheck(InstanceQuotaCheck):
 
 class NetworkLoadBalancerCountCheck(QuotaCheck):
     key = "elb_nlb_count"
-    description = "Network Load Balancers per Region"
     scope = QuotaScope.REGION
     service_code = 'elasticloadbalancing'
     quota_code = 'L-69A177A2'
+    description = "The maximum number of Network Load Balancers per Region"
 
     @property
     def current(self):
@@ -70,9 +70,9 @@ class NetworkLoadBalancerCountCheck(QuotaCheck):
 
 class ListenerPerNetworkLoadBalancerCountCheck(InstanceQuotaCheck):
     key = "elb_listeners_per_nlb"
-    description = "Listeners per Network Load Balancer"
     service_code = 'elasticloadbalancing'
     quota_code = 'L-57A373D6'
+    description = "The maximum number of listeners per Network Load Balancer"
     instance_id = 'Load Balancer ARN'
 
     @staticmethod
@@ -89,10 +89,10 @@ class ListenerPerNetworkLoadBalancerCountCheck(InstanceQuotaCheck):
 
 class ApplicationLoadBalancerCountCheck(QuotaCheck):
     key = "elb_alb_count"
-    description = "Application Load Balancers per Region"
     scope = QuotaScope.REGION
     service_code = 'elasticloadbalancing'
     quota_code = 'L-53DA6B97'
+    description = "The maximum number of Application Load Balancers per Region"
 
     @property
     def current(self):
@@ -101,9 +101,9 @@ class ApplicationLoadBalancerCountCheck(QuotaCheck):
 
 class ListenerPerApplicationLoadBalancerCountCheck(InstanceQuotaCheck):
     key = "elb_listeners_per_alb"
-    description = "Listeners per Application Load Balancer"
     service_code = 'elasticloadbalancing'
     quota_code = 'L-B6DF7632'
+    description = "The maximum number of listeners per Application Load Balancer"
     instance_id = 'Load Balancer ARN'
 
     @staticmethod
@@ -120,10 +120,10 @@ class ListenerPerApplicationLoadBalancerCountCheck(InstanceQuotaCheck):
 
 class TargetGroupCountCheck(QuotaCheck):
     key = "elb_target_group_count"
-    description = "Target Groups per Region"
     scope = QuotaScope.REGION
     service_code = 'elasticloadbalancing'
     quota_code = 'L-B22855CB'
+    description = "The maximum number of target groups per Region"
 
     @property
     def current(self):
@@ -132,9 +132,9 @@ class TargetGroupCountCheck(QuotaCheck):
 
 class TargetGroupsPerApplicationLoadBalancerCountCheck(InstanceQuotaCheck):
     key = "elb_target_groups_per_alb"
-    description = "Target groups per Application Load Balancer"
     service_code = 'elasticloadbalancing'
     quota_code = 'L-822D1B1B'
+    description = "The maximum number of target groups per Application Load Balancer"
     instance_id = 'Load Balancer ARN'
 
     @staticmethod

--- a/aws_quota/check/kms.py
+++ b/aws_quota/check/kms.py
@@ -4,10 +4,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class CryptographicOperationsRequestRate(QuotaCheck):
     key = "kms_cryptographic_operations_request_rate"
-    description = "Maximum requests for cryptographic operations with a symmetric CMK per second"
     scope = QuotaScope.REGION
     service_code = "kms"
     quota_code = "L-6E3AF000"
+    description = "Maximum requests for cryptographic operations with a symmetric CMK per second. This shared quota applies to Decrypt, Encrypt, GenerateDataKey, GenerateDataKeyWithoutPlaintext, GenerateMac, GenerateRandom, ReEncrypt, and VerifyMac requests. When you reach this quota, KMS rejects this type of request for the remainder of the interval."
 
     @property
     def current(self):

--- a/aws_quota/check/lambdas.py
+++ b/aws_quota/check/lambdas.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class FunctionAndLayerStorageCheck(QuotaCheck):
     key = "lambda_function_storage"
-    description = "Lambda function and layer storage"
     scope = QuotaScope.REGION
     service_code = 'lambda'
     quota_code = 'L-2ACBD22F'
+    description = "The amount of storage that's available for deployment packages and layer archives in the current Region."
 
     @property
     def current(self):

--- a/aws_quota/check/rds.py
+++ b/aws_quota/check/rds.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class RDSDBInstanceCountCheck(QuotaCheck):
     key = "rds_instances"
-    description = "RDS instances per Region"
     service_code = "rds"
     scope = QuotaScope.REGION
     quota_code = "L-7B6409FD"
+    description = "The maximum number of DB instances allowed in this account in the current Region"
 
     @property
     def current(self) -> int:
@@ -17,10 +17,10 @@ class RDSDBInstanceCountCheck(QuotaCheck):
 
 class RDSDBParameterGroupsCountCheck(QuotaCheck):
     key = "rds_parameter_groups"
-    description = "RDS parameter groups per Region"
     service_code = "rds"
     scope = QuotaScope.REGION
     quota_code = "L-DE55804A"
+    description = "The maximum number of parameter groups"
 
     @property
     def current(self) -> int:
@@ -31,10 +31,10 @@ class RDSDBParameterGroupsCountCheck(QuotaCheck):
 
 class RDSDBClusterParameterGroupCountCheck(QuotaCheck):
     key = "rds_cluster_parameter_groups"
-    description = "RDS cluster parameter groups per Region"
     service_code = "rds"
     scope = QuotaScope.REGION
     quota_code = "L-E4C808A8"
+    description = "The maximum number of DB cluster parameter groups"
 
     @property
     def current(self) -> int:
@@ -45,10 +45,10 @@ class RDSDBClusterParameterGroupCountCheck(QuotaCheck):
 
 class RDSEventSubscriptions(QuotaCheck):
     key = "rds_event_subscriptions"
-    description = "RDS event subscriptions per Region"
     service_code = "rds"
     scope = QuotaScope.REGION
     quota_code = "L-A59F4C87"
+    description = "The maximum number of event subscriptions"
 
     @property
     def current(self) -> int:
@@ -59,10 +59,10 @@ class RDSEventSubscriptions(QuotaCheck):
 
 class RDSDBSnapshotsCheck(QuotaCheck):
     key = "rds_instance_snapshots"
-    description = "Manual DB instance snapshots per Region"
     service_code = "rds"
     scope = QuotaScope.REGION
     quota_code = "L-272F1212"
+    description = "The maximum number of manual DB instance snapshots"
 
     @property
     def current(self) -> int:
@@ -73,10 +73,10 @@ class RDSDBSnapshotsCheck(QuotaCheck):
 
 class RDSDBClusterSnapshotsCheck(QuotaCheck):
     key = "rds_cluster_snapshots"
-    description = "Manual DB cluster snapshots per Region"
     service_code = "rds"
     scope = QuotaScope.REGION
     quota_code = "L-9B510759"
+    description = "The maximum number of manual DB cluster snapshots"
 
     @property
     def current(self) -> int:

--- a/aws_quota/check/route53resolver.py
+++ b/aws_quota/check/route53resolver.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class EndpointCountCheck(QuotaCheck):
     key = "route53resolver_endpoint_count"
-    description = "Route53 Resolver endpoints per Region"
     scope = QuotaScope.REGION
     service_code = 'route53resolver'
     quota_code = 'L-4A669CC0'
+    description = "Resolver endpoints per AWS Region"
 
     @property
     def current(self):
@@ -14,10 +14,10 @@ class EndpointCountCheck(QuotaCheck):
 
 class RulesCountCheck(QuotaCheck):
     key = "route53resolver_rule_count"
-    description = "Route53 Resolver rules per Region"
     scope = QuotaScope.REGION
     service_code = 'route53resolver'
     quota_code = 'L-51D8A1FB'
+    description = "Maximum number of resolver rules per AWS Region"
 
     @property
     def current(self):
@@ -25,10 +25,10 @@ class RulesCountCheck(QuotaCheck):
 
 class RuleAssociationsCountCheck(QuotaCheck):
     key = "route53resolver_rule_association_count"
-    description = "Route53 Resolver rule associations per Region"
     scope = QuotaScope.REGION
     service_code = 'route53resolver'
     quota_code = 'L-94E19253'
+    description = "Maximum number of associations between resolver rules and VPCs per AWS Region"
 
     @property
     def current(self):

--- a/aws_quota/check/s3.py
+++ b/aws_quota/check/s3.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class BucketCountCheck(QuotaCheck):
     key = "s3_bucket_count"
-    description = "The number of Amazon S3 general purpose buckets that you can create in an account"
     scope = QuotaScope.ACCOUNT
     service_code = 's3'
     quota_code = 'L-DC2B2D3D'
+    description = "The number of Amazon S3 general purpose buckets that you can create in an account"
 
     @property
     def current(self):

--- a/aws_quota/check/secretsmanager.py
+++ b/aws_quota/check/secretsmanager.py
@@ -3,10 +3,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class SecretCountCheck(QuotaCheck):
     key = "secretsmanager_secrets_count"
-    description = "Secrets per Account"
     scope = QuotaScope.ACCOUNT
     service_code = 'secretsmanager'
     quota_code = 'L-2F66C23C'
+    description = "The maximum number of secrets in each AWS Region of this AWS account."
 
     @property
     def current(self):

--- a/aws_quota/check/ses.py
+++ b/aws_quota/check/ses.py
@@ -4,10 +4,10 @@ from .quota_check import QuotaCheck, QuotaScope
 
 class TopicCountCheck(QuotaCheck):
     key = "ses_daily_sends"
-    description = "SES messages sent during the last 24 hours"
     scope = QuotaScope.REGION
     service_code = 'ses'
     quota_code = 'L-804C8AE8'
+    description = "The maximum number of emails that you can send in a 24-hour period for this account in the current Region."
 
     @property
     def current(self):

--- a/aws_quota/check/sns.py
+++ b/aws_quota/check/sns.py
@@ -16,10 +16,10 @@ def get_topic_attributes(session: boto3.Session, topic_arn) -> typing.List[str]:
 
 class TopicCountCheck(QuotaCheck):
     key = "sns_topics_count"
-    description = "SNS topics per Account"
     scope = QuotaScope.ACCOUNT
     service_code = 'sns'
     quota_code = 'L-61103206'
+    description = "The maximum number of Amazon SNS topics that an AWS account can create across all regions."
 
     @property
     def current(self):
@@ -27,10 +27,10 @@ class TopicCountCheck(QuotaCheck):
 
 class PendingSubscriptionCountCheck(QuotaCheck):
     key = "sns_pending_subscriptions_count"
-    description = "Pending SNS subscriptions per Account"
     scope = QuotaScope.ACCOUNT
     service_code = 'sns'
     quota_code = 'L-1A43D3DB'
+    description = "The maximum number of pending subscriptions per AWS account, across all regions."
 
     @property
     def current(self):
@@ -45,9 +45,9 @@ class PendingSubscriptionCountCheck(QuotaCheck):
 
 class SubscriptionsPerTopicCheck(InstanceQuotaCheck):
     key = "sns_subscriptions_per_topic"
-    description = "SNS subscriptions per topics"
     service_code = 'sns'
     quota_code = 'L-A4340BCD'
+    description = "The maximum number of subscriptions per topic, including confirmed and pending subscriptions."
     instance_id = 'Topic ARN'
 
     @staticmethod

--- a/aws_quota/check/vpc.py
+++ b/aws_quota/check/vpc.py
@@ -89,10 +89,10 @@ def get_all_network_acls(session: boto3.Session) -> typing.List[dict]:
 
 class VpcCountCheck(QuotaCheck):
     key = "vpc_count"
-    description = "VPCs per Region"
     scope = QuotaScope.REGION
     service_code = 'vpc'
     quota_code = 'L-F678F1CE'
+    description = "The maximum number of VPCs per Region. This quota is directly tied to the maximum number of internet gateways per Region."
 
     @property
     def current(self):
@@ -101,10 +101,10 @@ class VpcCountCheck(QuotaCheck):
 
 class InternetGatewayCountCheck(QuotaCheck):
     key = "ig_count"
-    description = "VPC internet gateways per Region"
     scope = QuotaScope.REGION
     service_code = 'vpc'
     quota_code = 'L-A4707A72'
+    description = "The maximum number of internet gateways per Region. This quota is directly tied to the maximum number of VPCs per Region. To increase this quota, increase the number of VPCs per Region."
 
     @property
     def current(self):
@@ -112,10 +112,10 @@ class InternetGatewayCountCheck(QuotaCheck):
 
 class VpcEndpointCountCheck(QuotaCheck):
     key = "vpc_endpoint"
-    description = "Gateway VPC endpoints per Region"
     scope = QuotaScope.REGION
     service_code = 'vpc'
     quota_code = 'L-1B52E74A'
+    description = "The maximum number of gateway VPC endpoints per Region. The maximum is 255 gateway endpoints per VPC."
 
     @property
     def current(self):
@@ -123,10 +123,10 @@ class VpcEndpointCountCheck(QuotaCheck):
 
 class NetworkInterfaceCountCheck(QuotaCheck):
     key = "ni_count"
-    description = "VPC network interfaces per Region"
     scope = QuotaScope.REGION
     service_code = 'vpc'
     quota_code = 'L-DF5E4CA3'
+    description = "The maximum number of network interfaces per Region."
 
     @property
     def current(self):
@@ -135,10 +135,10 @@ class NetworkInterfaceCountCheck(QuotaCheck):
 
 class SecurityGroupCountCheck(QuotaCheck):
     key = "sg_count"
-    description = "VPC security groups per Region"
     scope = QuotaScope.REGION
     service_code = 'vpc'
     quota_code = 'L-E79EC296'
+    description = "The maximum number of VPC security groups per Region."
 
     @property
     def current(self):
@@ -146,10 +146,10 @@ class SecurityGroupCountCheck(QuotaCheck):
 
 class NatGatewayCountCheck(InstanceQuotaCheck):
     key = "nat_count"
-    description = "The maximum number of NAT gateways per Availability Zone"
     scope = QuotaScope.INSTANCE
     service_code = 'vpc'
     quota_code = 'L-FE5A380F'
+    description = "The maximum number of NAT gateways per Availability Zone. This includes NAT gateways in the pending, active, or deleting state."
     instance_id = 'Availability Zone Name'
 
     @staticmethod
@@ -162,9 +162,9 @@ class NatGatewayCountCheck(InstanceQuotaCheck):
 
 class RulesPerSecurityGroupCheck(InstanceQuotaCheck):
     key = "vpc_rules_per_sg"
-    description = "Rules per VPC security group"
     service_code = 'vpc'
     quota_code = 'L-0EA8095F'
+    description = "The maximum number of inbound or outbound rules per VPC security group (120 rules in total). This quota is enforced separately for IPv4 and IPv6 rules. A rule that references a security group or prefix list ID counts as one rule each for IPv4 and IPv6. This quota multiplied by the security groups per network interface quota cannot exceed 1000."
     instance_id = 'Security Group ID'
 
     @staticmethod
@@ -182,9 +182,9 @@ class RulesPerSecurityGroupCheck(InstanceQuotaCheck):
 
 class RouteTablesPerVpcCheck(InstanceQuotaCheck):
     key = "vpc_route_tables_per_vpc"
-    description = "Route Tables per VPC"
     service_code = 'vpc'
     quota_code = 'L-589F43AA'
+    description = "The maximum number of route tables per VPC. The main route table counts toward this quota."
     instance_id = 'VPC ID'
 
     @staticmethod
@@ -205,9 +205,9 @@ class RouteTablesPerVpcCheck(InstanceQuotaCheck):
 
 class RoutesPerRouteTableCheck(InstanceQuotaCheck):
     key = "vpc_routes_per_route_table"
-    description = "Routes per Route Table"
     service_code = 'vpc'
     quota_code = 'L-93826ACB'
+    description = "The maximum number of non-propagated routes per route table. This quota can be increased up to a maximum of 1000; however, network performance might be impacted. This quota is enforced separately for IPv4 and IPv6 routes."
     instance_id = 'Route Table ID'
 
     @staticmethod
@@ -225,9 +225,9 @@ class RoutesPerRouteTableCheck(InstanceQuotaCheck):
 
 class SubnetsPerVpcCheck(InstanceQuotaCheck):
     key = "vpc_subnets_per_vpc"
-    description = "Subnets per VPC"
     service_code = 'vpc'
     quota_code = 'L-407747CB'
+    description = "The maximum number of subnets per VPC."
     instance_id = 'VPC ID'
 
     @staticmethod
@@ -248,9 +248,9 @@ class SubnetsPerVpcCheck(InstanceQuotaCheck):
 
 class AclsPerVpcCheck(InstanceQuotaCheck):
     key = "vpc_acls_per_vpc"
-    description = "Network ACLs per VPC"
     service_code = 'vpc'
     quota_code = 'L-B4A6D682'
+    description = "The maximum number of network ACLs per VPC."
     instance_id = 'VPC ID'
 
     @staticmethod
@@ -271,9 +271,9 @@ class AclsPerVpcCheck(InstanceQuotaCheck):
 
 class RulesPerAclCheck(InstanceQuotaCheck):
     key = "vpc_rules_per_acl"
-    description = "Rules per Network ACL"
     service_code = 'vpc'
     quota_code = 'L-2AEEBF1A'
+    description = "The maximum number of inbound rules or outbound rules per network ACL (a total of 40 rules). This includes both IPv4 and IPv6 rules, and the default deny rules. This quota can be increased up to a maximum of 40; however, network performance might be impacted."
     instance_id = 'Network ACL ID'
 
     @staticmethod
@@ -291,9 +291,9 @@ class RulesPerAclCheck(InstanceQuotaCheck):
 
 class Ipv4CidrBlocksPerVpcCheck(InstanceQuotaCheck):
     key = "vpc_ipv4_cidr_blocks_per_vpc"
-    description = "IPv4 CIDR blocks per VPC"
     service_code = 'vpc'
     quota_code = 'L-83CA0A9D'
+    description = "The maximum number of IPv4 CIDR blocks per VPC. The primary CIDR block and all secondary CIDR blocks count toward this quota. This quota can be increased up to a maximum of 50."
     instance_id = 'VPC ID'
 
     @staticmethod
@@ -311,9 +311,9 @@ class Ipv4CidrBlocksPerVpcCheck(InstanceQuotaCheck):
 
 class Ipv6CidrBlocksPerVpcCheck(InstanceQuotaCheck):
     key = "vpc_ipv6_cidr_blocks_per_vpc"
-    description = "IPv6 CIDR blocks per VPC"
     service_code = 'vpc'
     quota_code = 'L-085A6257'
+    description = "The maximum number of IPv6 CIDR blocks per VPC."
     instance_id = 'VPC ID'
 
     @staticmethod
@@ -333,9 +333,9 @@ class Ipv6CidrBlocksPerVpcCheck(InstanceQuotaCheck):
 
 class ActiveVpcPeeringConnectionsPerVpcCheck(InstanceQuotaCheck):
     key = "vpc_peering_connections_per_vpc"
-    description = "Active VPC peering connections per VPC"
     service_code = 'vpc'
     quota_code = 'L-7E9ECCDB'
+    description = "The maximum number of active VPC peering connections per VPC. This quota can be increased up to a maximum of 125."
     instance_id = 'VPC ID'
 
     @staticmethod

--- a/tools/update_descriptions.py
+++ b/tools/update_descriptions.py
@@ -1,0 +1,74 @@
+import ast
+import fileinput
+import json
+import re
+import urllib.request
+from aws_quota.check import ALL_CHECKS
+
+descriptions = {}
+services = set()
+
+for chk in ALL_CHECKS:
+    if not chk.service_code or not chk.quota_code:
+        continue
+    try:
+        # undocumented way to fetch service quota descriptions, no guarantees this won't change later
+        contents = urllib.request.urlopen(
+            "https://dt4ho68y70y55.cloudfront.net/en/{}/{}/description".format(
+                chk.service_code, chk.quota_code
+            )
+        ).read()
+        data = json.loads(contents.decode("utf-8"))
+        descriptions[(data['ServiceCode'], data['LimitCode'])] = data['LimitDescription']
+        services.add(data['ServiceCode'],)
+    except Exception as e:
+        print(
+            "Failed to get description for {}/{} : {}".format(
+                chk.service_code, chk.quota_code, e
+            )
+        )
+
+r_desc = re.compile(r"(\s+description\s+=\s).*")
+r_service = re.compile(r"\s+service_code\s+=\s(.*)")
+r_quota = re.compile(r"\s+quota_code\s+=\s(.*)")
+
+for s in set(services):
+    filename = "aws_quota/check/{}.py".format(s)
+    if s == "elasticloadbalancing":
+        filename = "aws_quota/check/elb.py"
+    elif s == "lambda":
+        filename = "aws_quota/check/lambdas.py"
+    elif s == "iam":
+        continue
+
+    try:
+        service = None
+        quota = None
+        with fileinput.FileInput(filename, inplace=True) as file:
+            for line in file:
+                if r_desc.match(line):
+                    continue
+
+                find_svc = r_service.findall(line)
+                if find_svc:
+                    service = ast.literal_eval(find_svc[0])
+
+                find_quota = r_quota.findall(line)
+                if find_quota:
+                    quota =  ast.literal_eval(find_quota[0])
+
+                print(line, end='')
+                if service and quota:
+                    dsc = descriptions[(service, quota)]
+                    print('    description = "{}"'.format(dsc))
+                    service = None
+                    quota = None
+
+        
+        print("Updated {} description in {}".format(chk.quota_code, filename))
+    except Exception as e:
+        print(
+            "Failed to update description for {}/{} : {}".format(
+                chk.service_code, chk.quota_code, e
+            )
+        )

--- a/tools/update_descriptions.py
+++ b/tools/update_descriptions.py
@@ -44,6 +44,7 @@ for s in set(services):
     try:
         service = None
         quota = None
+        # inject description into check class
         with fileinput.FileInput(filename, inplace=True) as file:
             for line in file:
                 if r_desc.match(line):
@@ -64,7 +65,6 @@ for s in set(services):
                     service = None
                     quota = None
 
-        
         print("Updated {} description in {}".format(chk.quota_code, filename))
     except Exception as e:
         print(


### PR DESCRIPTION
### Summary

AWS quota descriptions are a bit of a mess and some of them are incorrect and misleading.
Problem is, that AWS Service Quota API doesn't provide descriptions for the limits as well, however they are present on the UI. If data is on then we can fetch it as well, so I found undocumented API that has all the descriptions, for example:


```json
curl -s https://dt4ho68y70y55.cloudfront.net/en/ec2/L-0263D0A3/description | jq
{
  "ServiceCode": "ec2",
  "LimitDescription": "The maximum number of Elastic IP addresses that you can allocate for EC2-VPC in this Region.",
  "LimitCode": "L-0263D0A3",
  "UpdatedAt": "1559601342012"
}
```

Since this is undocumented API we can't really rely on it in the long term, so I wrote a small script to update descriptions for existing checks, see `tools/update_descriptions.py`.