### PR TITLE
Fix quota scopes

### DIFF
--- a/aws_quota/check/appmesh.py
+++ b/aws_quota/check/appmesh.py
@@ -4,7 +4,7 @@ from .quota_check import QuotaCheck, QuotaScope
 class MeshCountCheck(QuotaCheck):
     key = "am_mesh_count"
     description = "App Meshes per Account"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = 'appmesh'
     quota_code = 'L-AC861A39'
 

--- a/aws_quota/check/cloudformation.py
+++ b/aws_quota/check/cloudformation.py
@@ -4,7 +4,7 @@ from .quota_check import QuotaCheck, QuotaScope
 class StackCountCheck(QuotaCheck):
     key = "cf_stack_count"
     description = "Cloud Formation Stack count"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = 'cloudformation'
     quota_code = 'L-0485CB21'
 

--- a/aws_quota/check/ec2.py
+++ b/aws_quota/check/ec2.py
@@ -41,7 +41,7 @@ def get_all_spot_requests(session: boto3.Session):
 class OnDemandStandardInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_standard_count"
     description = "Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) EC2 instances"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-1216C47A"
 
@@ -54,7 +54,7 @@ class OnDemandStandardInstanceCountCheck(QuotaCheck):
 class OnDemandFInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_f_count"
     description = "Running On-Demand F EC2 instances"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-74FC7D96"
 
@@ -67,7 +67,7 @@ class OnDemandFInstanceCountCheck(QuotaCheck):
 class OnDemandGInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_g_count"
     description = "Running On-Demand G EC2 instances"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-DB2E81BA"
 
@@ -80,7 +80,7 @@ class OnDemandGInstanceCountCheck(QuotaCheck):
 class OnDemandInfInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_inf_count"
     description = "Running On-Demand Inf EC2 instances"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-1945791B"
 
@@ -93,7 +93,7 @@ class OnDemandInfInstanceCountCheck(QuotaCheck):
 class OnDemandPInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_p_count"
     description = "Running On-Demand P EC2 instances"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-417A185B"
 
@@ -106,7 +106,7 @@ class OnDemandPInstanceCountCheck(QuotaCheck):
 class OnDemandXInstanceCountCheck(QuotaCheck):
     key = "ec2_on_demand_x_count"
     description = "Running On-Demand X EC2 instances"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-7295265B"
 
@@ -119,7 +119,7 @@ class OnDemandXInstanceCountCheck(QuotaCheck):
 class SpotStandardRequestCountCheck(QuotaCheck):
     key = "ec2_spot_standard_count"
     description = "All Standard (A, C, D, H, I, M, R, T, Z) EC2 Spot Instance Requests"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-34B43A08"
 
@@ -132,7 +132,7 @@ class SpotStandardRequestCountCheck(QuotaCheck):
 class SpotFRequestCountCheck(QuotaCheck):
     key = "ec2_spot_f_count"
     description = "All F EC2 Spot Instance Requests"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-88CF9481"
 
@@ -145,7 +145,7 @@ class SpotFRequestCountCheck(QuotaCheck):
 class SpotGRequestCountCheck(QuotaCheck):
     key = "ec2_spot_g_count"
     description = "All G EC2 Spot Instance Requests"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-3819A6DF"
 
@@ -158,7 +158,7 @@ class SpotGRequestCountCheck(QuotaCheck):
 class SpotInfRequestCountCheck(QuotaCheck):
     key = "ec2_spot_inf_count"
     description = "All Inf EC2 Spot Instance Requests"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-B5D1601B"
 
@@ -171,7 +171,7 @@ class SpotInfRequestCountCheck(QuotaCheck):
 class SpotPRequestCountCheck(QuotaCheck):
     key = "ec2_spot_p_count"
     description = "All P EC2 Spot Instance Requests"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-7212CCBC"
 
@@ -184,7 +184,7 @@ class SpotPRequestCountCheck(QuotaCheck):
 class SpotXRequestCountCheck(QuotaCheck):
     key = "ec2_spot_x_count"
     description = "All X EC2 Spot Instance Requests"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = "ec2"
     quota_code = "L-E3A00192"
 
@@ -197,7 +197,7 @@ class SpotXRequestCountCheck(QuotaCheck):
 class ElasticIpCountCheck(QuotaCheck):
     key = "ec2_eip_count"
     description = "EC2 VPC Elastic IPs"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = 'ec2'
     quota_code = 'L-0263D0A3'
 
@@ -208,8 +208,8 @@ class ElasticIpCountCheck(QuotaCheck):
 
 class TransitGatewayCountCheck(QuotaCheck):
     key = "ec2_tgw_count"
-    description = "Transit Gateways per Account"
-    scope = QuotaScope.ACCOUNT
+    description = "Transit gateways per Region per account"
+    scope = QuotaScope.REGION
     service_code = 'ec2'
     quota_code = 'L-A2478D36'
 

--- a/aws_quota/check/elasticbeanstalk.py
+++ b/aws_quota/check/elasticbeanstalk.py
@@ -4,7 +4,7 @@ from .quota_check import QuotaCheck, QuotaScope
 class ApplicationCountCheck(QuotaCheck):
     key = "elasticbeanstalk_application_count"
     description = "Elastic Beanstalk Applications per Account"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = 'elasticbeanstalk'
     quota_code = 'L-1CEABD17'
 
@@ -16,7 +16,7 @@ class ApplicationCountCheck(QuotaCheck):
 class EnvironmentCountCheck(QuotaCheck):
     key = "elasticbeanstalk_environment_count"
     description = "Elastic Beanstalk Environments per Account"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = 'elasticbeanstalk'
     quota_code = 'L-8EFC1C51'
 

--- a/aws_quota/check/iam.py
+++ b/aws_quota/check/iam.py
@@ -13,6 +13,7 @@ class GroupCountCheck(QuotaCheck):
     key = "iam_group_count"
     description = "IAM groups per Account"
     scope = QuotaScope.ACCOUNT
+    service_code = "iam"
 
     @property
     def maximum(self):
@@ -27,6 +28,7 @@ class UsersCountCheck(QuotaCheck):
     key = "iam_user_count"
     description = "IAM users per Account"
     scope = QuotaScope.ACCOUNT
+    service_code = "iam"
 
     @property
     def maximum(self):
@@ -41,6 +43,7 @@ class PolicyCountCheck(QuotaCheck):
     key = "iam_policy_count"
     description = "IAM policies per Account"
     scope = QuotaScope.ACCOUNT
+    service_code = "iam"
 
     @property
     def maximum(self):
@@ -55,6 +58,7 @@ class PolicyVersionCountCheck(QuotaCheck):
     key = "iam_policy_version_count"
     description = "IAM policy versions in use per Account"
     scope = QuotaScope.ACCOUNT
+    service_code = "iam"
 
     @property
     def maximum(self):
@@ -69,6 +73,7 @@ class ServerCertificateCountCheck(QuotaCheck):
     key = "iam_server_certificate_count"
     description = "IAM server certificates per Account"
     scope = QuotaScope.ACCOUNT
+    service_code = "iam"
 
     @property
     def maximum(self):
@@ -83,6 +88,7 @@ class AttachedPolicyPerUserCheck(InstanceQuotaCheck):
     key = "iam_attached_policy_per_user"
     description = "Attached IAM policies per user"
     instance_id = "User Name"
+    service_code = "iam"
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
@@ -103,6 +109,7 @@ class AttachedPolicyPerGroupCheck(InstanceQuotaCheck):
     key = "iam_attached_policy_per_group"
     description = "Attached IAM policies per group"
     instance_id = "Group Name"
+    service_code = "iam"
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
@@ -123,6 +130,7 @@ class AttachedPolicyPerRoleCheck(InstanceQuotaCheck):
     key = "iam_attached_policy_per_role"
     description = "Attached IAM policies per role"
     instance_id = "Role Name"
+    service_code = "iam"
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:

--- a/aws_quota/check/route53.py
+++ b/aws_quota/check/route53.py
@@ -8,6 +8,7 @@ class HostedZoneCountCheck(QuotaCheck):
     key = "route53_hosted_zone_count"
     description = "Route53 Hosted Zones per Account"
     scope = QuotaScope.ACCOUNT
+    service_code = "route53"
 
     @property
     def maximum(self):
@@ -22,6 +23,7 @@ class HealthCheckCountCheck(QuotaCheck):
     key = "route53_health_check_count"
     description = "Route53 Health Checks per Account"
     scope = QuotaScope.ACCOUNT
+    service_code = "route53"
 
     @property
     def maximum(self):
@@ -36,6 +38,7 @@ class ReusableDelegationSetCountCheck(QuotaCheck):
     key = "route53_reusable_delegation_set_count"
     description = "Route53 Reusable Delegation Sets per Account"
     scope = QuotaScope.ACCOUNT
+    service_code = "route53"
 
     @property
     def maximum(self):
@@ -50,6 +53,7 @@ class TrafficPolicyCountCheck(QuotaCheck):
     key = "route53_traffic_policy_count"
     description = "Route53 Traffic Policies per Account"
     scope = QuotaScope.ACCOUNT
+    service_code = "route53"
 
     @property
     def maximum(self):
@@ -64,6 +68,7 @@ class TrafficPolicyInstanceCountCheck(QuotaCheck):
     key = "route53_traffic_policy_instance_count"
     description = "Route53 Traffic Policy Instances per Account"
     scope = QuotaScope.ACCOUNT
+    service_code = "route53"
 
     @property
     def maximum(self):
@@ -78,6 +83,7 @@ class RecordsPerHostedZoneCheck(InstanceQuotaCheck):
     key = "route53_records_per_hosted_zone"
     description = "Records per Route53 Hosted Zone"
     instance_id = 'Hosted Zone ID'
+    service_code = "route53"
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:
@@ -102,6 +108,7 @@ class AssociatedVpcHostedZoneCheck(InstanceQuotaCheck):
     key = "route53_vpcs_per_hosted_zone"
     description = "Associated VPCs per Route53 Hosted Zone"
     instance_id = 'Hosted Zone ID'
+    service_code = "route53"
 
     @staticmethod
     def get_all_identifiers(session: boto3.Session) -> typing.List[str]:

--- a/aws_quota/check/secretsmanager.py
+++ b/aws_quota/check/secretsmanager.py
@@ -4,7 +4,7 @@ from .quota_check import QuotaCheck, QuotaScope
 class SecretCountCheck(QuotaCheck):
     key = "secretsmanager_secrets_count"
     description = "Secrets per Account"
-    scope = QuotaScope.ACCOUNT
+    scope = QuotaScope.REGION
     service_code = 'secretsmanager'
     quota_code = 'L-2F66C23C'
 


### PR DESCRIPTION
### Summary

A lot of quota scopes are incorrectly configured, and even more, quite often they are hard to find.
Sometimes actual scope (region or account) can be found only in quota description or documentation.

Hence, another PR:
- https://github.com/gravitational/aws-quota-checker/pull/20


Most of the AWS quotas are regional, except some exceptions of global services like IAM, Route53 or S3. Bunch of SNS quotas seems to be account level as well.