### PR TITLE
Added support for Core team metrics

### DIFF
--- a/aws_quota/check/__init__.py
+++ b/aws_quota/check/__init__.py
@@ -4,6 +4,7 @@ from .autoscaling import *
 from .cloudformation import *
 from .dynamodb import *
 from .ebs import *
+from .ecr import *
 from .ec2 import *
 from .ecs import *
 from .eks import *

--- a/aws_quota/check/ec2.py
+++ b/aws_quota/check/ec2.py
@@ -239,3 +239,29 @@ class LaunchTemplatesCount(QuotaCheck):
     @property
     def current(self):
         return self.count_paginated_results("ec2", "describe_launch_templates", "LaunchTemplates")
+
+class AmiCount(QuotaCheck):
+    key = "ec2_ami_count"
+    scope = QuotaScope.REGION
+    service_code = 'ec2'
+    quota_code = 'L-B665C33B'
+    description = "The maximum number of public and private AMIs allowed in this Region. These include available, disabled, and pending AMIs, and AMIs in the Recycle Bin."
+
+    @property
+    def current(self):
+        return self.count_paginated_results("ec2", "describe_images", "Images", 
+                                            {"Owners": ["self"], "IncludeDeprecated": True, "IncludeDisabled": True}) + \
+            self.count_paginated_results("ec2", "list_images_in_recycle_bin", "Images")
+
+class PublicAmiCount(QuotaCheck):
+    key = "ec2_public_ami_count"
+    scope = QuotaScope.REGION
+    service_code = 'ec2'
+    quota_code = 'L-0E3CBAB9'
+    description = "The maximum number of public AMIs, including public AMIs in the Recycle Bin, allowed in this Region."
+
+    @property
+    def current(self):
+        return self.count_paginated_results("ec2", "describe_images", "Images", 
+                                            {"Owners": ["self"], "IncludeDeprecated": True, "IncludeDisabled": True, 
+                                             "Filters":[{"Name": "is-public", "Values": ["true"]}]})

--- a/aws_quota/check/ecr.py
+++ b/aws_quota/check/ecr.py
@@ -1,0 +1,43 @@
+from typing import List
+from .quota_check import InstanceQuotaCheck, QuotaScope
+from aws_quota.utils import get_paginated_results
+
+import boto3
+import cachetools
+
+
+@cachetools.cached(cache=cachetools.TTLCache(maxsize=1, ttl=60))
+def get_all_repositories(session: boto3.Session) -> List[str]:
+    services = ['ecr']
+    # ECR is available in all regions, but ecr-public is only available in us-east-1
+    if session.region_name == 'us-east-1':
+        services.append('ecr-public')
+
+    return [
+        repository['repositoryArn'] 
+        for service in services
+        for repository in get_paginated_results(session, service, 'describe_repositories', 'repositories')
+    ]
+
+@cachetools.cached(cache=cachetools.TTLCache(10000, 60))    # 10k = default number of max registries per account
+def get_repository_images(session: boto3.Session, repository_arn: str) -> List[str]:
+    arn_parts = repository_arn.split(':')
+    service = arn_parts[2]
+    repository_name = arn_parts[5].removeprefix("repository/")
+    return get_paginated_results(session, service, "describe_images", "imageDetails", {'repositoryName': repository_name})
+
+class ImagesPerRepository(InstanceQuotaCheck):
+    key = "ecr_images_per_repository"
+    scope = QuotaScope.INSTANCE
+    service_code = 'ecr'
+    quota_code = 'L-03A36CE1'
+    description = "The maximum number of images per repository."
+    instance_id = 'Repository ARN'
+
+    @staticmethod
+    def get_all_identifiers(session: boto3.Session) -> List[str]:
+        return get_all_repositories(session)
+
+    @property
+    def current(self):
+        return len(get_repository_images(self.boto_session, self.instance_id))


### PR DESCRIPTION
Hi folks. Internal tools would like to setup monitoring of some AWS metrics. I stumbled upon this repo while looking for a solution... really glad to see that somebody else already forked this 😀.

I've added a few metrics to monitor AMI quota limits, and ECR quota limits. Both of these have caused major problems when hit during security releases, delaying our releases. These resources have also cost us several hundreds of thousands of dollars when not cleaned up properly. If you guys don't mind owning this code, we'd like to add these metrics.

I have tested these changes locally against the release prod account, and they all work. The ECR image counter metric takes a long time to populate. We have 50k accounts and on my laptop it takes around a minute. We might want to increase the cache TTL. What do you think?