### PR TITLE
Added support for publishing image to GHCR, and semver tags

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - teleport
+      - fred/add-ghcr-publishing-2
     tags:
       - v*
   workflow_dispatch:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - teleport
-      - fred/add-ghcr-publishing-2
     tags:
       - v*
   workflow_dispatch:
@@ -44,16 +43,16 @@ jobs:
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         
-      # - name: Configure AWS credentials
-      #   uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
-      #   with:
-      #     aws-region: ${{ env.AWS_REGION }}
-      #     role-to-assume: ${{ env.AWS_ROLE }}
-      # - name: Login to ECR
-      #   id: login-ecr
-      #   uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
-      #   with:
-      #     registry-type: public
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+        with:
+          aws-region: ${{ env.AWS_REGION }}
+          role-to-assume: ${{ env.AWS_ROLE }}
+      - name: Login to ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
+        with:
+          registry-type: public
 
       - name: Login to GitHub Container Registry
         id: login-ghcr
@@ -68,6 +67,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
+            ${{ steps.login-ecr.outputs.registry }}/${{ github.repository }}
             ghcr.io/${{ github.repository }}
           flavor: |
             latest=false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -72,8 +72,8 @@ jobs:
             latest=false
           tags: |
             type=sha,prefix={{branch}}-,suffix=-{{date 'YYYYMMDDTHHmmss'}},format=short,enable=true
-            type=semver,pattern={{major}},enable=${{ github.event_name == 'event_name' && startsWith(github.ref, 'refs/tags/v') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'event_name' && startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}},enable=${{ github.event_name == 'event_name' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'event_name' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
             type=semver,pattern={{version}},enable=${{ github.event_name == 'event_name' && startsWith(github.ref, 'refs/tags/v') }}
   
       - name: Build the Docker image and push

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -2,7 +2,9 @@ name: cd
 on:
   push:
     branches:
-    - teleport
+      - teleport
+    tags:
+      - v*
   workflow_dispatch:
 
 permissions:
@@ -70,6 +72,9 @@ jobs:
             latest=false
           tags: |
             type=sha,prefix={{branch}}-,suffix=-{{date 'YYYYMMDDTHHmmss'}},format=short,enable=true
+            type=semver,pattern={{major}},enable=${{ github.event_name == 'event_name' && startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'event_name' && startsWith(github.ref, 'refs/tags/v') }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'event_name' && startsWith(github.ref, 'refs/tags/v') }}
   
       - name: Build the Docker image and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -33,6 +33,8 @@ jobs:
     env:
       AWS_REGION: us-east-1
       AWS_ROLE: arn:aws:iam::146628656107:role/aws-quota-checker-github-action-ecr-role
+    permissions:
+      packages: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -63,7 +63,7 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ steps.login-ghcr.outputs.registry }}/${{ github.repository }}
+            ghcr.io/${{ github.repository }}
           flavor: |
             latest=false
           tags: |

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,11 +70,13 @@ jobs:
             ghcr.io/${{ github.repository }}
           flavor: |
             latest=false
+          # Enable sha tag on branch push events and workflow dispatches.
+          # Enable semver tags on tag push events, but don't overwrite major/minor tags for prereleases.
           tags: |
-            type=sha,prefix={{branch}}-,suffix=-{{date 'YYYYMMDDTHHmmss'}},format=short,enable=true
-            type=semver,pattern={{major}},enable=${{ github.event_name == 'event_name' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
-            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'event_name' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
-            type=semver,pattern={{version}},enable=${{ github.event_name == 'event_name' && startsWith(github.ref, 'refs/tags/v') }}
+            type=sha,prefix={{branch}}-,suffix=-{{date 'YYYYMMDDTHHmmss'}},format=short,enable=${{ startsWith(github.ref, 'refs/heads/') }}
+            type=semver,pattern={{major}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            type=semver,pattern={{major}}.{{minor}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-') }}
+            type=semver,pattern={{version}},enable=${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
   
       - name: Build the Docker image and push
         uses: docker/build-push-action@v5

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,16 +39,16 @@ jobs:
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
-        with:
-          aws-region: ${{ env.AWS_REGION }}
-          role-to-assume: ${{ env.AWS_ROLE }}
-      - name: Login to ECR
-        id: login-ecr
-        uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
-        with:
-          registry-type: public
+      # - name: Configure AWS credentials
+      #   uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
+      #   with:
+      #     aws-region: ${{ env.AWS_REGION }}
+      #     role-to-assume: ${{ env.AWS_ROLE }}
+      # - name: Login to ECR
+      #   id: login-ecr
+      #   uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
+      #   with:
+      #     registry-type: public
 
       - name: Login to GitHub Container Registry
         id: login-ghcr
@@ -63,7 +63,6 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: |
-            ${{ steps.login-ecr.outputs.registry }}/${{ github.repository }}
             ${{ steps.login-ghcr.outputs.registry }}/${{ github.repository }}
           flavor: |
             latest=false

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -34,21 +34,29 @@ jobs:
       AWS_REGION: us-east-1
       AWS_ROLE: arn:aws:iam::146628656107:role/aws-quota-checker-github-action-ecr-role
     steps:
-      - name: checkout
+      - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: setup docker buildx
+      - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         
-      - name: configure AWS credentials
+      - name: Configure AWS credentials
         uses: aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502 # v4
         with:
           aws-region: ${{ env.AWS_REGION }}
           role-to-assume: ${{ env.AWS_ROLE }}
-      - name: login to ECR
+      - name: Login to ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@062b18b96a7aff071d4dc91bc00c4c1a7945b076 # v2
         with:
           registry-type: public
+
+      - name: Login to GitHub Container Registry
+        id: login-ghcr
+        uses: docker/login-action@343f7c4344506bcbf9b4de18042ae17996df046d # v3.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Prepare docker labels and tags
         id: meta
@@ -56,6 +64,7 @@ jobs:
         with:
           images: |
             ${{ steps.login-ecr.outputs.registry }}/${{ github.repository }}
+            ${{ steps.login-ghcr.outputs.registry }}/${{ github.repository }}
           flavor: |
             latest=false
           tags: |


### PR DESCRIPTION
This PR adds GHCR image publishing. This is useful internally so that we don't have to choose between either authenticating with AWS, or getting rate limited. This PR also adds semver tags for published images.

I'll probably file a follow up PR at some point that adds a Helm chart, which will also be pushed to ghcr.

Passing tag event build: https://github.com/gravitational/aws-quota-checker/actions/runs/8667301252/job/23770040440
Passing workflow dispatch event build: https://github.com/gravitational/aws-quota-checker/actions/runs/8667339188/job/23770168528
Passing push event build: https://github.com/gravitational/aws-quota-checker/actions/runs/8667356669/job/23770221471