### PR TITLE
cd: explicitly set id-token permission for build-push job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -9,7 +9,6 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   test:
@@ -37,6 +36,7 @@ jobs:
       AWS_ROLE: arn:aws:iam::146628656107:role/aws-quota-checker-github-action-ecr-role
     permissions:
       packages: write
+      id-token: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4


### PR DESCRIPTION
### Summary

ECR permissions are failing with

> Run aws-actions/configure-aws-credentials@e3dd6a429d7300a6a4c196c26e071d42e0343502
> It looks like you might be trying to authenticate with OIDC. Did you mean to set the `id-token` permission? If you are not trying to authenticate with OIDC and the action is working successfully, you can ignore this message.
> Error: Credentials could not be loaded, please check your action inputs: Could not load credentials from any providers


after following PR was merged:
- #28 