### PR TITLE
Make quota limit overridable

### DIFF
--- a/aws_quota/check/quota_check.py
+++ b/aws_quota/check/quota_check.py
@@ -34,6 +34,7 @@ class QuotaCheck:
     scope: QuotaScope = None
     service_code: str = None
     quota_code: str = None
+    quota_limit_override: int = None
     warning_threshold: float = None
     error_threshold: float = None
     # retries are needed to handle rate limiting
@@ -80,6 +81,9 @@ class QuotaCheck:
 
     @property
     def maximum(self) -> int:
+        if self.quota_limit_override is not None:
+            return self.quota_limit_override
+
         try:
             return int(get_service_quota(self.sq_client, self.service_code, self.quota_code)['Value'])
         except self.sq_client.exceptions.NoSuchResourceException:


### PR DESCRIPTION
We recently found out the hard way that the Service Quota service does not always provide an accurate response for some quotas. In fact, for some quotas there is no way at all to determine the actual, AWS-applied limit. This PR adds support for a `--limit-override` parameter that allows us to explicitly set limits at start time.

Here's an example of how to use this new parameter:
```
aws-quota-checker --limit-override ecr_images_per_repository 40000 --limit-override asg_count 10 prometheus-exporter ecr_images_per_repository,asg_count
```

I've tested this locally and it works properly.