### PR TITLE
Added multiarch image support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -87,3 +87,6 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          platforms: |
+            linux/amd64
+            linux/arm64


### PR DESCRIPTION
This will make it possible for this image to run on graviton nodes, and will make local mac development a little bit easier.

PR check will verify that this works properly.