### PR TITLE
Add standard labels to request duration metrics

### DIFF
--- a/aws_quota/prometheus.py
+++ b/aws_quota/prometheus.py
@@ -126,7 +126,8 @@ class PrometheusExporter:
                     try:
                         with self.timeit_gauge(
                             name,
-                            documentation=f'Time to collect {check.description} Limit'
+                            documentation=f'Time to collect {check.description} Limit',
+                            labels=self.default_labels | labels
                         ):
                             value = check.maximum
 
@@ -166,7 +167,8 @@ class PrometheusExporter:
                     try:
                         with self.timeit_gauge(
                             name,
-                            documentation=f'Time to collect {check.description}'
+                            documentation=f'Time to collect {check.description}',
+                            labels=self.default_labels | labels
                         ):
                             value = check.current
 


### PR DESCRIPTION
This adds some additional labels (quota name, service code, scope, etc.) to request duration metrics. Note that this should not increase the cardinality at all, as every exported metric that this affects was already unique.