### PR TITLE
Rename `instance` label to `aws_resource`

### DIFF
--- a/aws_quota/check/quota_check.py
+++ b/aws_quota/check/quota_check.py
@@ -75,7 +75,7 @@ class QuotaCheck:
             if isinstance(self.instance_id, dict):
                 label_values.update(self.instance_id)
             else:
-                label_values['instance'] = self.instance_id
+                label_values['aws_resource'] = self.instance_id
 
         return label_values
 


### PR DESCRIPTION
The `instance` label typically stores an ARN or resource ID for a resource being monitored. This poses a problem when using the prometheus exporter with prometheus, because [Prometheus automatically adds the `instance` label to metrics in a way that is particularly difficult to work around](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#relabel_config:~:text=After%20relabeling%2C%20the%20instance%20label%20is%20set%20to%20the%20value%20of%20__address__%20by%20default%20if%20it%20was%20not%20set%20during%20relabeling.).

This PR renames the `instance` label to `aws_resource`, which should more accurately describe the label's purpose, and not collide with Prometheus' `instance` label.