### PR TITLE
Added CI/CD for Helm chart

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -26,11 +26,14 @@ jobs:
         run: python setup.py bdist_wheel
       - name: build docker image
         run: docker build . --tag gravitational/aws-quota-checker:test
+      - name: build helm chart
+        working-directory: helm
+        run: helm package . --version "1.2.3-dev" --app-version "4.5.6-dev"
 
-  build_and_push_docker_image:
+  build_and_push_artifacts:
     runs-on: ubuntu-latest
     needs: [test]
-    name: Build and push Docker image
+    name: Build and push artifacts
     env:
       AWS_REGION: us-east-1
       AWS_ROLE: arn:aws:iam::146628656107:role/aws-quota-checker-github-action-ecr-role
@@ -40,6 +43,9 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
+        with:
+          fetch-depth: 0
+
       - name: Setup docker buildx
         uses: docker/setup-buildx-action@v3
         
@@ -87,3 +93,33 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      
+      - name: Build and publish the Helm chart
+        working-directory: helm
+        env:
+          EVENT_TYPE: ${{ (github.event_name == 'push' && (startsWith(github.ref, 'refs/tags/v') && 'tag' ) || 'commit' ) || 'dispatch'}}
+          IMAGE_VERSION: ${{ steps.meta.outputs.version }}
+        run: |
+          # Determine chart version to set
+          case "${EVENT_TYPE}" in
+            tag)
+              CHART_VERSION="${GITHUB_REF_NAME}"
+              ;;
+            commit)
+              ;&
+            dispatch)
+              CHART_VERSION="$(git describe --tags --dirty --long --match "v[[:digit:]]*.[[:digit:]]*.[[:digit:]]")"
+              ;;
+            *)
+              echo "Unknown event type '${EVENT_TYPE}', workflow bug?" >&2
+              exit 1
+              ;;
+          esac
+
+          # Build/package the chart
+          helm package . --version "${CHART_VERSION#v}" --app-version "${IMAGE_VERSION#v}"
+          ARTIFACT_NAME=$(find . -name '*.tgz' -exec basename {} \; | head -n 1)
+
+          # Publish the chart
+          helm push "$ARTIFACT_NAME" "oci://ghcr.io/gravitational/charts"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,3 +18,6 @@ jobs:
         run: python setup.py bdist_wheel
       - name: build docker image
         run: docker build . --tag gravitational/aws-quota-checker:test
+      - name: build helm chart
+        working-directory: helm
+        run: helm package .


### PR DESCRIPTION
This will publish the chart to GHA. Test build of the chart is available here: https://github.com/gravitational/aws-quota-checker/pkgs/container/charts%2Faws-quota-checker/222837616?tag=0.0.0-fred.10

This PR is pointing at #29, but I'll most it to master once #29 lands.