### PR TITLE
Fixed CD workflow failing on commit builds

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -111,7 +111,7 @@ jobs:
             commit)
               ;&
             dispatch)
-              CHART_VERSION="$(git describe --tags --dirty --long --match "v[[:digit:]]*.[[:digit:]]*.[[:digit:]]")"
+              CHART_VERSION="$(git describe --tags --dirty --long --match "v[[:digit:]]*.[[:digit:]]*.[[:digit:]]*")"
               ;;
             *)
               echo "Unknown event type '${EVENT_TYPE}', workflow bug?" >&2
@@ -119,8 +119,13 @@ jobs:
               ;;
           esac
 
+          # Trim `v` prefix if exists
+          CHART_VERSION=${CHART_VERSION#v}
+          IMAGE_VERSION=${IMAGE_VERSION#v}
+
           # Build/package the chart
-          helm package . --version "${CHART_VERSION#v}" --app-version "${IMAGE_VERSION#v}"
+          echo "Setting chart version to ${CHART_VERSION} and image version to ${IMAGE_VERSION}"
+          helm package . --version "${CHART_VERSION}" --app-version "${IMAGE_VERSION}"
           ARTIFACT_NAME=$(find . -name '*.tgz' -exec basename {} \; | head -n 1)
 
           # Publish the chart


### PR DESCRIPTION
The `CHART_VERSION` tag lookup needed an extra `*` at the end.

Passing workflow run: https://github.com/gravitational/aws-quota-checker/actions/runs/9307528704/job/25619005447