### PR TITLE
Fixed alerts not including the resource name when applicable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed alerts not including the resource name when applicable [#40](https://github.com/gravitational/aws-quota-checker/pull/40)
+
 ## [1.13.0] - 2024-05-30
 This is the first release of this project under Gravitational management.
 

--- a/helm/templates/alert-rule/quotaRule.yaml
+++ b/helm/templates/alert-rule/quotaRule.yaml
@@ -46,7 +46,7 @@ spec:
           annotations:
             description: >-
               Quota threshold of {{ mulf .threshold 100 }}% for {{ "{{" }} $labels.quota {{ "}}" }}
-              {{ "{{" }} if $labels.resource {{ "}}" }} on resource {{ "{{" }} $labels.resource {{ "}}" }}{{ "{{" }} end {{ "}}" }}
+              {{ "{{" }} if $labels.aws_resource {{ "}}" }} on resource {{ "{{" }} $labels.aws_resource {{ "}}" }}{{ "{{" }} end {{ "}}" }}
               in {{ "{{" }} $labels.account {{ "}}" }}/{{ "{{" }}$labels.region{{ "}}" }} has been reached.
             summary: Reached quota threshold for {{ "{{" }} $labels.quota {{ "}}" }}
           {{- if $.Values.alerting.prometheusRules.additionalLabels }}


### PR DESCRIPTION
Missed this in the Helm chart PR. The correct label is `aws_resource` not `resource`.