### PR TITLE
Added support for setting limit overrides in the Helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added support for setting limit overrides in the Helm chart [#41](https://github.com/gravitational/aws-quota-checker/pull/41)
+
 ## [1.13.0] - 2024-05-30
 This is the first release of this project under Gravitational management.
 

--- a/helm/templates/deployment.yaml
+++ b/helm/templates/deployment.yaml
@@ -46,6 +46,11 @@ spec:
             {{- if .Values.checker.enableDebugLogging }}
             - --debug
             {{- end }}
+            {{- range $checkName, $overrideValue := .Values.checker.aws.limitOverrides }}
+            - --limit-override
+            - {{ $checkName | quote }}
+            - {{ $overrideValue | quote }}
+            {{- end }}
             - prometheus-exporter
             - --port
             - "8080"

--- a/helm/values.yaml
+++ b/helm/values.yaml
@@ -21,6 +21,8 @@ checker:
       - us-west-2
     enabledChecks:
       - all
+    limitOverrides:
+      # ecr_images_per_repository: 40000
     # credentialSecretName: ""  # Optional. Contains the name of a secret in the namespace that has standard AWS credential environment vars.
     # profileName: ""
     # quotaLimitCheckIntervalSeconds: 600


### PR DESCRIPTION
Manually tested this in the gha-eks-dev cluster and it seems to work.