### PR TITLE
Release v1.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.14.1] - 2024-07-15
+
+- Added cache to Route53 calls to avoid rate-limitting [#43](https://github.com/gravitational/aws-quota-checker/pull/43)
+
 ## [1.14.0] - 2024-05-31
 
 ### Added


### PR DESCRIPTION
## [1.14.1] - 2024-07-15

- Added cache to Route53 calls to avoid rate-limitting [#43](https://github.com/gravitational/aws-quota-checker/pull/43)