### PR TITLE
Add `quota_region_override` for quotas that report in us-east-1 only

### DIFF
--- a/aws_quota/check/quota_check.py
+++ b/aws_quota/check/quota_check.py
@@ -35,6 +35,7 @@ class QuotaCheck:
     service_code: str = None
     quota_code: str = None
     quota_limit_override: int = None
+    quota_region_override: str = None
     warning_threshold: float = None
     error_threshold: float = None
     # retries are needed to handle rate limiting
@@ -45,12 +46,18 @@ class QuotaCheck:
         super().__init__()
 
         self.boto_session = boto_session
-        self.sq_client = boto_session.client('service-quotas', config=Config(
+        client_config = Config(
             retries = {
                 'max_attempts': self.retry_attempts,
                 'mode': 'standard'
             }
-        ))
+        )
+        
+        client_region=None
+        if self.scope == QuotaScope.ACCOUNT and self.quota_region_override:
+            client_region = self.quota_region_override
+
+        self.sq_client = boto_session.client('service-quotas', config=client_config, region_name=client_region)
 
     def __str__(self) -> str:
         return f'{self.key}{self.label_values}'

--- a/aws_quota/check/s3.py
+++ b/aws_quota/check/s3.py
@@ -6,6 +6,7 @@ class BucketCountCheck(QuotaCheck):
     scope = QuotaScope.ACCOUNT
     service_code = 's3'
     quota_code = 'L-DC2B2D3D'
+    quota_region_override = 'us-east-1'
     description = "The number of Amazon S3 general purpose buckets that you can create in an account"
 
     @property


### PR DESCRIPTION
### Summary

AWS S3 is a global service and default quota value is reported from us-east-1 only. Added `quota_region_override=us-east-1` to be able to fetch it.


AWS CLI Example:

```shell
➜  aws-quota-checker git:(taras/add-quota-region-override) aws service-quotas get-aws-default-service-quota --service-code s3 --quota-code L-DC2B2D3D --region us-east-1
{
    "Quota": {
        "ServiceCode": "s3",
        "ServiceName": "Amazon Simple Storage Service (Amazon S3)",
        "QuotaArn": "arn:aws:servicequotas:::s3/L-DC2B2D3D",
        "QuotaCode": "L-DC2B2D3D",
        "QuotaName": "General purpose buckets",
        "Value": 10000.0,
        "Unit": "None",
        "Adjustable": true,
        "GlobalQuota": true,
        "UsageMetric": {
            "MetricNamespace": "AWS/Usage",
            "MetricName": "ResourceCount",
            "MetricDimensions": {
                "Class": "None",
                "Resource": "GeneralPurposeBuckets",
                "Service": "S3",
                "Type": "Resource"
            },
            "MetricStatisticRecommendation": "Maximum"
        },
        "Period": {
            "PeriodValue": 5,
            "PeriodUnit": "MINUTE"
        }
    }
}
➜  aws-quota-checker git:(taras/add-quota-region-override) aws service-quotas get-aws-default-service-quota --service-code s3 --quota-code L-DC2B2D3D --region us-west-2

An error occurred (NoSuchResourceException) when calling the GetAWSDefaultServiceQuota operation:
```

- https://github.com/aws/aws-cli/issues/7962
- https://github.com/aws/aws-cli/issues/8238



Resolves https://github.com/gravitational/aws-quota-checker/issues/45