### PR TITLE
Release v15.5.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.15.4] - 2026-01-05
+
 ### Fixed
 
 - Update and pin all dependencies


### PR DESCRIPTION
## [1.15.4] - 2026-01-05

### Fixed

- Update and pin all dependencies
  - Update python to 3.14
  - Update boto3, click, cachetools
  - Pin all GitHub Action usages