### PR TITLE
Should exclude AWS service managed IP addresses

### DIFF
--- a/aws_quota/check/ec2.py
+++ b/aws_quota/check/ec2.py
@@ -203,7 +203,11 @@ class ElasticIpCountCheck(QuotaCheck):
 
     @property
     def current(self):
-        return len(self.boto_session.client('ec2').describe_addresses()['Addresses'])
+        return len([
+            address
+            for address in self.boto_session.client('ec2').describe_addresses()['Addresses']
+            if address.get('ServiceManaged') is None
+        ])
 
 
 class TransitGatewayCountCheck(QuotaCheck):
@@ -249,7 +253,7 @@ class AmiCount(QuotaCheck):
 
     @property
     def current(self):
-        return self.count_paginated_results("ec2", "describe_images", "Images", 
+        return self.count_paginated_results("ec2", "describe_images", "Images",
                                             {"Owners": ["self"], "IncludeDeprecated": True, "IncludeDisabled": True}) + \
             self.count_paginated_results("ec2", "list_images_in_recycle_bin", "Images")
 
@@ -262,6 +266,6 @@ class PublicAmiCount(QuotaCheck):
 
     @property
     def current(self):
-        return self.count_paginated_results("ec2", "describe_images", "Images", 
-                                            {"Owners": ["self"], "IncludeDeprecated": True, "IncludeDisabled": True, 
+        return self.count_paginated_results("ec2", "describe_images", "Images",
+                                            {"Owners": ["self"], "IncludeDeprecated": True, "IncludeDisabled": True,
                                              "Filters":[{"Name": "is-public", "Values": ["true"]}]})


### PR DESCRIPTION
This fixes issue #62  with AWS API not returning AWS service managed IP addresses, causing the check to show incorrect results.

For example, if you have no assigned addresses but 5 ALBs with public IP addresses, that would show a 100% utilization rate for the default limit of 5, instead of the expected 0%.